### PR TITLE
Specify java source as UTF-8

### DIFF
--- a/j-child/build.gradle
+++ b/j-child/build.gradle
@@ -11,6 +11,7 @@ configurations.compileClasspath.transitive = false
 version '0.1-SNAPSHOT'
 
 sourceCompatibility = 1.8
+compileJava.options.encoding = 'UTF-8'
 
 repositories {
   mavenCentral()


### PR DESCRIPTION
Avoid compile issue:
`
sweetchildomine/j-child/src/main/java/net/namingcrisis/sweetchildomine/jchild/CountingCircleGame.java:22: error: unmappable character for encoding ASCII
 *    sequential number, which we will refer to as it???s id.</li>
`